### PR TITLE
Pragma ignore intentional issues in test code

### DIFF
--- a/src/Tests/MorganStanley.Fdc3.Tests/AppIdentifierTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/AppIdentifierTests.cs
@@ -35,6 +35,8 @@ public class AppIdentifierTests
     [Fact]
     public void AppIdentifier_NullAppId_ThrowArgumentNullExecption()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new AppIdentifier(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 }

--- a/src/Tests/MorganStanley.Fdc3.Tests/AppIntentTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/AppIntentTests.cs
@@ -19,13 +19,17 @@ public class AppIntentTests
     [Fact]
     public void AppIntent_NullIntent_ThrowsArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new AppIntent(null, new[] { new AppMetadata("appid") }));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void AppIntent_NullApps_ThrowsArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new AppIntent(new IntentMetadata("name", "displayName"), null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]

--- a/src/Tests/MorganStanley.Fdc3.Tests/AppMetadataTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/AppMetadataTests.cs
@@ -19,7 +19,9 @@ public class AppMetadataTests
     [Fact]
     public void AppMetadata_NullAppId_ThrowsArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new AppMetadata(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]

--- a/src/Tests/MorganStanley.Fdc3.Tests/IChannelTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/IChannelTests.cs
@@ -22,7 +22,11 @@ public class IChannelTests
     public void AddContextListener_InvokesAddContextListenerWithNullContextType()
     {
         MockChannel channel = new MockChannel();
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         channel.AddContextListener<IContext>(null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning restore CS0618 // Type or member is obsolete
         Assert.True(channel.AddContextListenerInvoked);
     }
 
@@ -39,7 +43,9 @@ public class IChannelTests
         public IListener AddContextListener<T>(string? contextType, ContextHandler<T> handler) where T : IContext
         {
             this.AddContextListenerInvoked = true;
+#pragma warning disable CS8603 // Possible null reference return.
             return null;
+#pragma warning restore CS8603 // Possible null reference return.
         }
 
         public Task Broadcast(IContext context)

--- a/src/Tests/MorganStanley.Fdc3.Tests/IconTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/IconTests.cs
@@ -19,7 +19,9 @@ public class IconTests
     [Fact]
     public void Icon_NullSrc_ThrowsArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new Icon(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]

--- a/src/Tests/MorganStanley.Fdc3.Tests/ImageTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/ImageTests.cs
@@ -19,7 +19,9 @@ public class ImageTests
     [Fact]
     public void Image_NullSrc_ThrowsArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new Image(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]

--- a/src/Tests/MorganStanley.Fdc3.Tests/ImplementationMetadataTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/ImplementationMetadataTests.cs
@@ -21,31 +21,41 @@ public class ImplementationMetadataTests
     [Fact]
     public void ImplementationMetadata_NullFdc3Version_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new ImplementationMetadata(null, "provider", "providerversion", new OptionalDesktopAgentFeatures(), new AppMetadata("appid")));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void ImplementationMetadata_NullProvider_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new ImplementationMetadata("fdc3version", null, "providerversion", new OptionalDesktopAgentFeatures(), new AppMetadata("appid")));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void ImplementationMetadata_NullProviderVersion_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new ImplementationMetadata("fdc3version", "provider", null, new OptionalDesktopAgentFeatures(), new AppMetadata("appid")));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void ImplementationMetadata_NullOptionalFeatures_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new ImplementationMetadata("fdc3version", "provider", "providerversion", null, new AppMetadata("appid")));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void ImplementationMetadata_NullAppMetadata_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new ImplementationMetadata("fdc3version", "provider", "providerversion", new OptionalDesktopAgentFeatures(), null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]

--- a/src/Tests/MorganStanley.Fdc3.Tests/IntentMetadataTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/IntentMetadataTests.cs
@@ -19,13 +19,17 @@ public class IntentMetadataTests
     [Fact]
     public void IntentMetadata_NullName_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new IntentMetadata(null, "displayname"));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void IntentMetadata_NullDisplayName_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new IntentMetadata("name", null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]

--- a/src/Tests/MorganStanley.Fdc3.Tests/IntentResolutionTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.Tests/IntentResolutionTests.cs
@@ -19,13 +19,17 @@ public class IntentResolutionTests
     [Fact]
     public void IntentResolution_NullSource_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new MockIntentResolution(null, "intent", "version"));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]
     public void IntentResolution_NullIntent_ArgumentNullException()
     {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
         Assert.Throws<ArgumentNullException>(() => new MockIntentResolution(new AppMetadata("appid"), null, "version"));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
     }
 
     [Fact]


### PR DESCRIPTION
Intentional use of null values to params that are not nullable and other cases.  As we want to test these cases we need to have these bad use cases.