### PR TITLE
Fixing typos in comments.

### DIFF
--- a/src/Fdc3/IAppMetadata.cs
+++ b/src/Fdc3/IAppMetadata.cs
@@ -58,7 +58,7 @@ namespace MorganStanley.Fdc3
 
         /// <summary>
         /// The type of output returned for any intent specified during resolution. May express a particular context type,
-        /// channel, or channel with specified type
+        /// channel, or channel with specified type.
         /// </summary>
         string? ResultType { get; }
     }

--- a/src/Fdc3/IChannel.cs
+++ b/src/Fdc3/IChannel.cs
@@ -36,7 +36,7 @@ namespace MorganStanley.Fdc3
 
         /// <summary>
         /// Channels may be visualized and selectable by users. DisplayMetadata may be used to provide hints on how to see them.
-        /// For app channels, displayMetadata would typically not be present
+        /// For app channels, displayMetadata would typically not be present.
         /// </summary>
         IDisplayMetadata? DisplayMetadata { get; }
 


### PR DESCRIPTION
Adding period to close mark the end of the sentences.