### PR TITLE
Downgrade newtonsoft to first 13 minor

### DIFF
--- a/src/Fdc3.NewtonsoftJson/MorganStanley.Fdc3.NewtonsoftJson.csproj
+++ b/src/Fdc3.NewtonsoftJson/MorganStanley.Fdc3.NewtonsoftJson.csproj
@@ -39,7 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
+++ b/src/Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
@@ -20,7 +20,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
Let consumer define 13.x or later version to use without forced upgrade