### PR TITLE
Create CVE Scanning

### DIFF
--- a/.cve/allow-list.xml
+++ b/.cve/allow-list.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -27,7 +27,7 @@ jobs:
           format: 'HTML'
           out: 'reports'
           args: >
-            --suppression ./cve/allow-list.xml
+            --suppression ~/./cve/allow-list.xml
             --failOnCVSS 7
             --enableRetired
       - name: Upload Test results

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -27,7 +27,7 @@ jobs:
           format: 'HTML'
           out: 'reports'
           args: >
-            --suppression ~/./cve/allow-list.xml
+            --suppression .cve/allow-list.xml
             --failOnCVSS 7
             --enableRetired
       - name: Upload Test results

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build project with dotnet
         run: dotnet build --configuration Release
-        working-directory: fdc3-dotnet
+        working-directory: '.'
       - name: List vulnerable libraries
         run: dotnet list package --vulnerable --include-transitive
-        working-directory: 'fdc3-dotnet'
+        working-directory: '.'
       - name: Depcheck
         uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
         id: Depcheck

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build project with dotnet
         run: dotnet build --configuration Release
-        working-directory: '.'
+        working-directory: '/src'
       - name: List vulnerable libraries
         run: dotnet list package --vulnerable --include-transitive
-        working-directory: '.'
+        working-directory: '/src'
       - name: Depcheck
         uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
         id: Depcheck

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Build project with dotnet
         run: dotnet build --configuration Release
-        working-directory: '/src'
+        working-directory: 'src'
       - name: List vulnerable libraries
         run: dotnet list package --vulnerable --include-transitive
-        working-directory: '/src'
+        working-directory: 'src'
       - name: Depcheck
         uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
         id: Depcheck

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -1,0 +1,38 @@
+name: CVE Scanning
+
+on:
+  push:
+
+jobs:
+  dotnet-modules-scan:
+    name: dotnet-scan
+    runs-on: ubuntu-latest
+    continue-on-error: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build project with dotnet
+        run: dotnet build --configuration Release
+        working-directory: fdc3-dotnet
+      - name: List vulnerable libraries
+        run: dotnet list package --vulnerable --include-transitive
+        working-directory: 'fdc3-dotnet'
+      - name: Depcheck
+        uses: dependency-check/Dependency-Check_Action@1b5d19fd4a32ff0ff982e8c9d8e27dbf7ac8a46c
+        id: Depcheck
+        with:
+          project: '.'
+          path: '.'
+          format: 'HTML'
+          out: 'reports'
+          args: >
+            --suppression ./cve/allow-list.xml
+            --failOnCVSS 7
+            --enableRetired
+      - name: Upload Test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Depcheck report
+          path: ${{ github.workspace }}/reports

--- a/src/Examples/WpfFdc3/WpfFdc3.csproj
+++ b/src/Examples/WpfFdc3/WpfFdc3.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CVE Scanning action that use DependencyCheck with allow-list.xml. 

Enable  `<EnableWindowsTargeting>true</EnableWindowsTargeting>` in  WpfFdc3.csproj because the action was failing if it's set to false.