### PR TITLE
Update test dependencies

### DIFF
--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/MorganStanley.Fdc3.AppDirectory.Tests.csproj
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/MorganStanley.Fdc3.AppDirectory.Tests.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
+++ b/src/Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
@@ -19,11 +19,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.14" />
-        <PackageReference Include="xunit" Version="2.6.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+        <PackageReference Include="xunit" Version="2.6.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/Tests/MorganStanley.Fdc3.Tests/MorganStanley.Fdc3.Tests.csproj
+++ b/src/Tests/MorganStanley.Fdc3.Tests/MorganStanley.Fdc3.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23577-04" />
+    <PackageReference Include="xunit" Version="2.6.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Microsoft.NET.Test.Sdk 17.9.0-preview-23577-04 has a fix to remove Nuget.Frameworks.dll from the build output as it is no longer necessary.  Once there is an official release it will be upgraded.  The Nuget.Frameworks.dll that gets copied to build output in 17.8.0 has a high CVE.